### PR TITLE
(GH-43) Add section on schema to Crescendo overview

### DIFF
--- a/reference/docs-conceptual/Crescendo/overview.md
+++ b/reference/docs-conceptual/Crescendo/overview.md
@@ -36,3 +36,18 @@ The documentation for Crescendo includes some new terminology.
 - **amplified command** - the cmdlet you created with Crescendo to wrap a command in a PowerShell
   function
   - For example: `Get-IpConfig -All`
+
+### The Crescendo configuration file schema
+
+When you author a Crescendo configuration file, you're writing JSON. For convenience,validation, and
+an improved developer experience, a
+[schema file is available][crescendo-schema].
+
+You can review the schema to see the required and optional configuration
+settings, their descriptions, and the value types they accept. When you
+[author your configuration file in Visual Studio Code Code][vscode-json],
+you get numerous helpful features, including IntelliSense, validation while you
+edit, and more.
+
+[crescendo-schema]: https://aka.ms/PowerShell/Crescendo/Schemas/2021-11
+[vscode-json]: https://code.visualstudio.com/Docs/languages/json


### PR DESCRIPTION
This PR adds a section to the Crescendo overview page to highlight the availability and usefulness of the provided JSON Schema for Crescendo configuration files.

- Resolves #43
- Resolves PowerShell/Crescendo#140