### PR TITLE
Fixed typo in `Register-SecretVault` reference

### DIFF
--- a/reference/ps-modules/Microsoft.PowerShell.SecretManagement/Register-SecretVault.md
+++ b/reference/ps-modules/Microsoft.PowerShell.SecretManagement/Register-SecretVault.md
@@ -27,7 +27,7 @@ cmdlet verifies that the specified module meets conformance requirements before 
 extension vault registry. Extension vaults are registered to the current user and do not affect
 other user vault registrations.
 
-The first fault registered with this cmdlet is automatically defined as the default vault even if
+The first vault registered with this cmdlet is automatically defined as the default vault even if
 the **DefaultVault** parameter is not specified.
 
 ## EXAMPLES


### PR DESCRIPTION
# PR Summary
Fixed typo:
Instead of, "The first **fault** registered with this cmdlet", it should be, "The first **vault** registered with this cmdlet"


## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide