### PR TITLE
WIP: [BrokenLinks] add missing breadcrumbs

### DIFF
--- a/reference/breadcrumb/toc.yml
+++ b/reference/breadcrumb/toc.yml
@@ -1,15 +1,25 @@
-items:
-  - name: Docs
-    tocHref: /
-    topicHref: /
+- name: Docs
+  tocHref: /
+  topicHref: /
+  items:
+  - name: PowerShell
+    tocHref: /powershell/
+    topicHref: /powershell
     items:
-      - name: PowerShell
-        tocHref: /powershell/
-        topicHref: /powershell
-        items:
-          - name: Utility Modules
-            tocHref: /powershell/utility-modules/
-            topicHref: /powershell/utility-modules/overview
-          - name: Utility Modules
-            tocHref: /powershell/module/
-            topicHref: /powershell/utility-modules/overview
+    - name: Utility Modules
+      tocHref: /powershell/utility-modules/
+      topicHref: /powershell/utility-modules/overview
+      items:
+      - name: Crescendo
+        tocHref: /powershell/module/crescendo/
+        topicHref: /powershell/utility-modules/crescendo/overview
+      - name: PlatyPS
+        tocHref: /powershell/module/platyps/
+        topicHref: /powershell/utility-modules/platyps/overview
+      - name: PSScriptAnalyzer
+        tocHref: /powershell/module/psscriptanalyzer/
+        topicHref: /powershell/utility-modules/psscriptanalyzer/overview
+      - name: SecretManagement and SecretStore
+        tocHref: /powershell/module/secretmanagement/
+        topicHref: /powershell/utility-modules/secretmanagement/overview
+        


### PR DESCRIPTION
# PR Summary

**Global effort to fix broken links**

The C+E Skilling team is fixing broken links on docs.microsoft.com. This effort will eliminate potential accessibility, security, and usability issues. This PR adds breadcrumbs for the utility modules and updates the config file's link to the breadcrumb TOC, which should point to the live path rather than the source path. Thanks!

## PR Checklist
- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].


[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide