### PR TITLE
(GH-70) Add `AvoidSemiColonsAsLineTerminators`

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/AvoidSemicolonsAsLineTerminators.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/AvoidSemicolonsAsLineTerminators.md
@@ -1,0 +1,58 @@
+---
+description: Avoid semicolons as line terminators
+ms.custom: PSSA v1.21.0
+ms.date: 07/25/2022
+ms.topic: reference
+title: AvoidSemicolonsAsLineTerminators
+---
+
+# AvoidSemicolonsAsLineTerminators
+
+**Severity Level: Warning**
+
+## Description
+
+Lines should not end with a semicolon.
+
+> [!NOTE]
+> This rule is not enabled by default. The user needs to enable it through settings.
+
+## Example
+
+### Wrong
+
+```powershell
+Install-Module -Name PSScriptAnalyzer; $a = 1 + $b;
+```
+
+```powershell
+Install-Module -Name PSScriptAnalyzer;
+$a = 1 + $b
+```
+
+### Correct
+
+```powershell
+Install-Module -Name PSScriptAnalyzer; $a = 1 + $b
+```
+
+```powershell
+Install-Module -Name PSScriptAnalyzer
+$a = 1 + $b
+```
+
+## Configuration
+
+```powershell
+Rules = @{
+    PSAvoidSemicolonsAsLineTerminators  = @{
+        Enable     = $true
+    }
+}
+```
+
+### Parameters
+
+#### Enable: bool (Default value is `$false`)
+
+Enable or disable the rule during ScriptAnalyzer invocation.

--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/README.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/README.md
@@ -23,6 +23,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [AvoidMultipleTypeAttributes<sup>1</sup>](./AvoidMultipleTypeAttributes.md)                       | Warning     |        Yes         |                 |
 | [AvoidNullOrEmptyHelpMessageAttribute](./AvoidNullOrEmptyHelpMessageAttribute.md)                 | Warning     |        Yes         |                 |
 | [AvoidOverwritingBuiltInCmdlets](./AvoidOverwritingBuiltInCmdlets.md)                             | Warning     |        Yes         |       Yes       |
+| [AvoidSemicolonsAsLineTerminators](./AvoidSemicolonsAsLineTerminators.md)                         | Warning     |         No         |                 |
 | [AvoidShouldContinueWithoutForce](./AvoidShouldContinueWithoutForce.md)                           | Warning     |        Yes         |                 |
 | [AvoidTrailingWhitespace](./AvoidTrailingWhitespace.md)                                           | Warning     |        Yes         |                 |
 | [AvoidUsingCmdletAliases](./AvoidUsingCmdletAliases.md)                                           | Warning     |        Yes         | Yes<sup>2</sup> |

--- a/reference/docs-conceptual/toc.yml
+++ b/reference/docs-conceptual/toc.yml
@@ -65,6 +65,8 @@ items:
             href: PSScriptAnalyzer/Rules/AvoidNullOrEmptyHelpMessageAttribute.md
           - name: AvoidOverwritingBuiltInCmdlets
             href: PSScriptAnalyzer/Rules/AvoidOverwritingBuiltInCmdlets.md
+          - name: AvoidSemicolonsAsLineTerminators
+            href: PSScriptAnalyzer/Rules/AvoidSemicolonsAsLineTerminators.md
           - name: AvoidShouldContinueWithoutForce
             href: PSScriptAnalyzer/Rules/AvoidShouldContinueWithoutForce.md
           - name: AvoidTrailingWhitespace


### PR DESCRIPTION
# PR Summary

This change adds the new `AvoidSemiColonsAsLineTerminators` rule
documentation to PSScriptAnalyzer.

- Resolves #70
- Fixes [AB#4588](https://dev.azure.com/content-learn/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/4588)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://docs.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://docs.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide