### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseApprovedVerbs.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseApprovedVerbs.md
@@ -15,7 +15,7 @@ All cmdlets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
-Additional documentation on approved verbs can be found in the microsoft docs page
+Additional documentation on approved verbs can be found at
 [Approved Verbs for PowerShell Commands](/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
 Some unapproved verbs are documented on the approved verbs page and point to approved alternatives.
 Try searching for the verb you used to find its approved form. For example, searching for `Read`,

--- a/reference/ps-modules/Microsoft.PowerShell.Crescendo/New-OutputHandler.md
+++ b/reference/ps-modules/Microsoft.PowerShell.Crescendo/New-OutputHandler.md
@@ -2,7 +2,7 @@
 external help file: Microsoft.PowerShell.Crescendo-help.xml
 Module Name: Microsoft.PowerShell.Crescendo
 ms.date: 11/09/2021
-online version:https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/new-outputhandler?view=ps-modules&wt.mc_id=ps-gethelp
+online version: https://docs.microsoft.com/powershell/module/microsoft.powershell.crescendo/new-outputhandler?view=ps-modules&wt.mc_id=ps-gethelp
 schema: 2.0.0
 ---
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
