### PR TITLE
(GH-116) Clarify `New-ExternalHelpCab` is Windows-only

### DIFF
--- a/reference/ps-modules/PlatyPS/New-ExternalHelpCab.md
+++ b/reference/ps-modules/PlatyPS/New-ExternalHelpCab.md
@@ -9,40 +9,50 @@ schema: 2.0.0
 # New-ExternalHelpCab
 
 ## SYNOPSIS
-Generates a .cab file.
+Generates a `.cab` file.
 
 ## SYNTAX
 
 ```
-New-ExternalHelpCab -CabFilesFolder <String> -LandingPagePath <String> -OutputFolder <String>
+New-ExternalHelpCab -CabFilesFolder <String> -LandingPagePath <String>
+ -OutputFolder <String>
  [-IncrementHelpVersion] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-The `New-ExternalHelpCab` cmdlet generates a .cab file that contains all the non-recursive content
+The `New-ExternalHelpCab` cmdlet generates a `.cab` file that contains all the non-recursive content
 in a folder. This cmdlet compresses the provided files.
+
+> [!NOTE]
+> This cmdlet depends on the `MakeCab.exe` native command, which is only available on Windows. This
+> cmdlet raises an error if used on non-Windows machines.
 
 We recommend that you provide as content only about_ topics and the output from the
 [New-ExternalHelp](New-ExternalHelp.md) cmdlet to this cmdlet.
 
-This cmdlet uses metadata stored in the module markdown file to name your .cab file. This naming
-matches the pattern that the Windows PowerShell help system requires for use as updatable help. This
+This cmdlet uses metadata stored in the module markdown file to name your `.cab` file. This naming
+matches the pattern that the PowerShell help system requires for use as updatable help. This
 metadata is part of the module file created using the [New-MarkdownHelp](New-MarkdownHelp.md)
 cmdlet with the **WithModulePage** parameter.
 
 This cmdlet also generates or updates an existing `helpinfo.xml` file. That file provides versioning
-and locale details to the Windows PowerShell help system.
+and locale details to the PowerShell help system.
 
 ## EXAMPLES
 
 ### Example 1: Create a CAB file
 
 ```powershell
-New-ExternalHelpCab -CabFilesFolder 'C:\Module\ExternalHelpContent' -LandingPagePath 'C:\Module\ModuleName.md' -OutputPath 'C:\Module\Cab\'
+$params = @{
+    CabFilesFolder  = 'C:\Module\ExternalHelpContent'
+    LandingPagePath = 'C:\Module\ModuleName.md'
+    OutputPath      = 'C:\Module\Cab\'
+}
+New-ExternalHelpCab @params
 ```
 
-This commmand creates a `.cab` file that contains the content folder files. The `.cab` file is named
+The cmdlet creates a `.cab` file that contains the content folder files. The `.cab` file is named
 for updatable help based on metadata. The command places the `.cab` file in the output folder.
 
 ## PARAMETERS
@@ -65,8 +75,8 @@ Accept wildcard characters: False
 
 ### -LandingPagePath
 
-Specifies the full path of the Module Markdown file that contains all the metadata required to name
-the .cab file. For the required metadata, run `New-MarkdownHelp` with the **WithLandingPage**
+Specifies the full path of the module Markdown file that contains all the metadata required to name
+the `.cab` file. For the required metadata, run `New-MarkdownHelp` with the **WithLandingPage**
 parameter.
 
 ```yaml
@@ -99,7 +109,7 @@ Accept wildcard characters: False
 
 ### -IncrementHelpVersion
 
-Automatically increment the help version in the module markdown file.
+Automatically increment the help version in the module Markdown file.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
# PR Summary

Prior to this change, the documentation didn't state that the PlatyPS cmdlet `New-ExternalHelpCab` only works on Windows, despite requiring the `MakeCab.exe` native command, which is only available on Windows.

This change adds a notice to the cmdlet documentation to clarify this limitation.

- Resolves #116
- Fixes [AB#41454](https://dev.azure.com/msft-skilling/cebd7ef5-4282-448b-9701-88c8637581b7/_workitems/edit/41454)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide