### PR TITLE
(AB-62321) Update outputs for GHA

### DIFF
--- a/.github/workflows/quality.pr.yml
+++ b/.github/workflows/quality.pr.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           $Check = "${{ contains(github.event.pull_request.title, 'Quality:') }}"
           "Check: $Check"
-          "::set-output name=check::$Check"
+          "check=$Check" >> $env:GITHUB_OUTPUT
 
   project:
     name: Add pull request to project


### PR DESCRIPTION
# PR Summary

This change updates the GitHub Actions workflows to use the environment file instead of the `::set-output` command.

This is required by May 31, 2023, as [announced by GitHub][01].

[01]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide