### PR TITLE
Codeblock array should use single quotes

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseCompatibleSyntax.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseCompatibleSyntax.md
@@ -22,9 +22,9 @@ PowerShell versions because they aren't able to parse the incompatible syntaxes.
         PSUseCompatibleSyntax = @{
             Enable = $true
             TargetVersions = @(
-                "6.0",
-                "5.1",
-                "4.0"
+                '6.0',
+                '5.1',
+                '4.0'
             )
         }
     }


### PR DESCRIPTION
Super minor, but the TargetVersions array inside of the hashtable should use single quotes for constant strings. Given the docs actually have a section on using single quotes for constant strings, I figured it was probably appropriate to submit a small PR for this :).

# PR Summary

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide