### PR TITLE
Update create-new-cmdlet.md to remove deprecated parameter

### DIFF
--- a/reference/docs-conceptual/Crescendo/get-started/create-new-cmdlet.md
+++ b/reference/docs-conceptual/Crescendo/get-started/create-new-cmdlet.md
@@ -76,7 +76,7 @@ HelpLinks               :
 OutputHandlers          :
 ```
 
-The following example shows how to create a new configuration file.
+The following example shows how to create a new configuration file. The file will be saved as Show-AzCmAgent.crescendo.json.
 
 ```powershell
 $parameters = @{
@@ -85,7 +85,7 @@ $parameters = @{
     OriginalName = "c:/program files/AzureConnectedMachineAgent/azcmagent.exe"
 }
 $CrescendoCommands += New-CrescendoCommand @parameters
-Export-CrescendoCommand -command $CrescendoCommands -fileName .\AzCmAgent.json
+Export-CrescendoCommand -command $CrescendoCommands
 ```
 
 Crescendo configuration file has a JSON schema and can contain one or more cmdlet definitions in an


### PR DESCRIPTION
# PR Summary

Export-CrescendoCommand no longer supports `-fileName` as a parameter. It supports -targetDirectory with the default being the current directory. The filename is standardised based off the parameters.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x ] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide