### PR TITLE
Fix Invoke-WmiObject cmdlet name

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/AvoidUsingWMICmdlet.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/AvoidUsingWMICmdlet.md
@@ -17,7 +17,7 @@ The following cmdlets should not be used:
 
 - `Get-WmiObject`
 - `Remove-WmiObject`
-- `Invoke-WmiObject`
+- `Invoke-WmiMethod`
 - `Register-WmiEvent`
 - `Set-WmiInstance`
 
@@ -38,7 +38,7 @@ Change to the equivalent CIM based cmdlet.
 
 - `Get-WmiObject` -> `Get-CimInstance`
 - `Remove-WmiObject` -> `Remove-CimInstance`
-- `Invoke-WmiObject` -> `Invoke-CimMethod`
+- `Invoke-WmiMethod` -> `Invoke-CimMethod`
 - `Register-WmiEvent` -> `Register-CimIndicationEvent`
 - `Set-WmiInstance` -> `Set-CimInstance`
 


### PR DESCRIPTION
Mentions `Invoke-WmiObject` in two instances, change to correct cmdlet name, `Invoke-WmiMethod`

<!--
    Delete this comment block and summarize your changes and list
    related issues here. For example:

    This changes fixes problem X in the documentation for Y.

    - Fixes #1234
    - Resolves #1235
-->

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide