### PR TITLE
added $file to the ArgumentList

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/create-custom-rule.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/create-custom-rule.md
@@ -97,7 +97,7 @@ Since version 1.17.0, you can include a **SuggestedCorrections** property of typ
 $objParams = @{
   TypeName = 'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent'
   ArgumentList = $startLineNumber, $endLineNumber, $startColumnNumber,
-                 $endColumnNumber, $correction, $optionalDescription
+                 $endColumnNumber, $correction, $file, $optionalDescription
 }
 $correctionExtent = New-Object @objParams
 $suggestedCorrections = New-Object System.Collections.ObjectModel.Collection[$($objParams.TypeName)]


### PR DESCRIPTION
# PR Summary
    This changes fixes unused variable $file in the documentation for creating custom PS Script Analyzer rules.

    - Fixes #197 
    - Resolves #197 

## PR Checklist

- [x] **Descriptive Title:** added optional $file parameter to the ArgumentList
- [x] **Summary:** The $file parameter is defined earlier in this code block but is never used. Added it to the Argument List.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].
