### PR TITLE
Typo correction in AvoidUsingPositionalParameters.md

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/AvoidUsingPositionalParameters.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/AvoidUsingPositionalParameters.md
@@ -33,7 +33,7 @@ Rules = @{
 
 ### Parameters
 
-#### AvoidUsingPositionalParameters: string[] (Default value is 'az')
+#### CommandAllowList: string[] (Default value is 'az')
 
 Commands to be excluded from this rule. `az` is excluded by default because starting with version 2.40.0 the entrypoint of the AZ CLI became an `az.ps1` script but this script does not have any named parameters and just passes them on using `$args` as is to the Python process that it starts, therefore it is still a CLI and not a PowerShell command.
 


### PR DESCRIPTION
Corrected the parameters list

# PR Summary

Just a small typo correction: the parameters list was using the rule name instead of the CommandAllowList parameter name.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [ x ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [ x ] **Summary:** This PR's summary describes the scope and intent of the change.
- [ x ] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [ x ] **Style:** This PR adheres to the [style guide][style].

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide