### PR TITLE
Use correct rule name in config example

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/ReviewUnusedParameter.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/ReviewUnusedParameter.md
@@ -23,7 +23,7 @@ been used in that scope.
 ```powershell
 @{
     Rules = @{
-        ReviewUnusedParameter = @{
+        PSReviewUnusedParameter = @{
             CommandsToTraverse = @(
                 'Invoke-PSFProtectedCommand'
             )


### PR DESCRIPTION
# PR Summary

Configuration settings example for `ReviewUnusedParameter` uses the rule name as displayed in the table / overview of the official [PSSA docs](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/readme?view=ps-modules)

But the "internal" or "object name" (is that the correct nomenclature?) for this rule is `PSReviewUnusedParameter` - as returned by `Get-ScriptAnalyzerRule` (and also like the config examples for all other rules in the PSSA docs)

## PR Checklist



- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].



[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide