### PR TITLE
Some fixes for `README.md`, `UseSingularNouns.md`

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/README.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/README.md
@@ -1,7 +1,7 @@
 ---
 description: List of PSScriptAnalyzer rules
 ms.custom: PSSA v1.22.0
-ms.date: 02/13/2024
+ms.date: 03/27/2024
 ms.topic: reference
 title: List of PSScriptAnalyzer rules
 ---
@@ -58,7 +58,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [ProvideCommentHelp](./ProvideCommentHelp.md)                                                     | Information |        Yes         |       Yes       |
 | [ReservedCmdletChar](./ReservedCmdletChar.md)                                                     | Error       |        Yes         |                 |
 | [ReservedParams](./ReservedParams.md)                                                             | Error       |        Yes         |                 |
-| [ReviewUnusedParameter](./ReviewUnusedParameter.md)                                               | Warning     |        Yes         |                 |
+| [ReviewUnusedParameter](./ReviewUnusedParameter.md)                                               | Warning     |        Yes         | Yes<sup>2</sup> |
 | [ShouldProcess](./ShouldProcess.md)                                                               | Warning     |        Yes         |                 |
 | [UseApprovedVerbs](./UseApprovedVerbs.md)                                                         | Warning     |        Yes         |                 |
 | [UseBOMForUnicodeEncodedFile](./UseBOMForUnicodeEncodedFile.md)                                   | Warning     |        Yes         |                 |
@@ -84,5 +84,5 @@ The PSScriptAnalyzer contains the following rule definitions.
 
 - <sup>1</sup> Rule is not available on all PowerShell versions, editions, or OS platforms. See the
   rule's documentation for details.
-- <sup>2</sup> The rule a configurable property, but the rule can't be disabled like other
+- <sup>2</sup> The rule has a configurable property, but the rule can't be disabled like other
   configurable rules.

--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseSingularNouns.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseSingularNouns.md
@@ -1,7 +1,7 @@
 ---
 description: Cmdlet Singular Noun
 ms.custom: PSSA v1.22.0
-ms.date: 03/26/2024
+ms.date: 03/27/2024
 ms.topic: reference
 title: UseSingularNouns
 ---
@@ -25,23 +25,23 @@ function Get-Elements {
 
 ```powershell
 Rules = @{
-    UseSingularNouns = @{
-        NounAllowList    = 'Data', 'Windows', 'Foos'
+    PSUseSingularNouns = @{
         Enable           = $true
+        NounAllowList    = 'Data', 'Windows', 'Foos'
     }
 }
 ```
 
 ### Parameters
 
-- `UseSingularNouns`: `string[]` (Default value is `{'Data', 'Windows'}`)
-
-  Commands to be excluded from this rule. `Data` and `Windows` are common false positives and are
-  excluded by default.
-
 - `Enable`: `bool` (Default value is `$true`)
 
   Enable or disable the rule during ScriptAnalyzer invocation.
+
+- `NounAllowList`: `string[]` (Default value is `{'Data', 'Windows'}`)
+
+  Commands to be excluded from this rule. `Data` and `Windows` are common false positives and are
+  excluded by default.
 
 ## How
 


### PR DESCRIPTION
# PR Summary

- `ReviewUnusedParameter` now has configurable options since latest PSScriptAnalyzer release, but the rule overview table did not reflect that yet
- Use "correct" rule name (`PSUseSingularNouns`) in example, for consistency with other included rules examples
- Fixed wrong parameter name in `UseSingularNouns.md` parameter section [1]
- Changed order in config example to be more like other built-in rules

[1] This seems to be the correct parameter name:
https://github.com/PowerShell/PSScriptAnalyzer/blob/a0365a56068f711ee1ec08fae11a85fcc1542f8c/Rules/UseSingularNouns.cs#L35-L38

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide