### PR TITLE
Update Update-CommandHelp.md

### DIFF
--- a/reference/ps-modules/Microsoft.PowerShell.PlatyPS/Update-CommandHelp.md
+++ b/reference/ps-modules/Microsoft.PowerShell.PlatyPS/Update-CommandHelp.md
@@ -88,7 +88,7 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByVale)
-Accept wildcard characters: False'
+Accept wildcard characters: False
 ```
 
 ### -Path


### PR DESCRIPTION
Fixing the yaml for LiteralPath parameter yaml block

# PR Summary

This pull request includes a minor correction to the `Update-CommandHelp.md` file in the `Microsoft.PowerShell.PlatyPS` module. Specifically, it removes an extraneous single quote from the `Accept wildcard characters` field in the parameter documentation.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide