### PR TITLE
Correct UseCorrectCasing typo for #341

### DIFF
--- a/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseCorrectCasing.md
+++ b/reference/docs-conceptual/PSScriptAnalyzer/Rules/UseCorrectCasing.md
@@ -25,7 +25,7 @@ commands. Using lowercase operators helps distinguish them from parameters.
 
 ```powershell
 Rules = @{
-    PS UseCorrectCasing = @{
+    PSUseCorrectCasing = @{
         Enable        = $true
         CheckCommands = $true
         CheckKeyword  = $true


### PR DESCRIPTION
# PR Summary

This changes fixes problem #341 in the documentation for `reference\docs-conceptual\PSScriptAnalyzer\Rules\UseCorrectCasing.md`.

- Fixes #341

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.
- [x] **Contributor's Guide:** I have read the [contributors guide][contrib].
- [x] **Style:** This PR adheres to the [style guide][style].

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->

[contrib]: https://learn.microsoft.com/powershell/scripting/community/contributing/overview
[style]: https://learn.microsoft.com/powershell/scripting/community/contributing/powershell-style-guide